### PR TITLE
Add environ and environ_pass parameters to exec/3

### DIFF
--- a/c_src/proto_command.h
+++ b/c_src/proto_command.h
@@ -23,8 +23,7 @@ struct comm_t {
       char *command;
       char **argv;
       char *cwd;
-      // TODO: struct { char *name; char *value } *env_set;
-      // TODO: char **env_clear;
+      char **env;
       unsigned int termsig;
       uint64_t sigmask; // ignored signals
       // modes:

--- a/c_src/supervisor_loop.c
+++ b/c_src/supervisor_loop.c
@@ -2,6 +2,7 @@
 
 #include <string.h>
 #include <stdio.h> // snprintf()
+#include <stdlib.h>
 
 #include <unistd.h>
 #include <sys/types.h>
@@ -679,8 +680,6 @@ int child_spawn(struct comm_t *cmd, child_t *child, void *buffer, int *fds)
     }
   }
 
-  // TODO: set environment
-
   struct sigaction ignore_action;
   memset(&ignore_action, 0, sizeof(ignore_action));
   ignore_action.sa_handler = SIG_IGN;
@@ -689,7 +688,7 @@ int child_spawn(struct comm_t *cmd, child_t *child, void *buffer, int *fds)
     if ((cmd->exec_opts.sigmask & (((uint64_t)1) << (sig - 1))) != 0)
       sigaction(sig, &ignore_action, NULL);
 
-  execve(cmd->exec_opts.command, cmd->exec_opts.argv, NULL);
+  execve(cmd->exec_opts.command, cmd->exec_opts.argv, cmd->exec_opts.env);
   // if we got here, exec() must have failed
   int error[2] = { STAGE_EXEC, errno };
   send(fds_confirm[WRITE_END], error, sizeof(error), MSG_NOSIGNAL);

--- a/src/subproc.erl
+++ b/src/subproc.erl
@@ -75,6 +75,8 @@
                      | {user, uid() | string()}
                      | {group, gid() | string()}
                      | {cd, file:filename()}
+                     | {environ, map()}
+                     | {environ_pass, [string()]}
                      | {argv0, file:filename()}.
 %% Options controlling how the subprocess is executed.
 %%
@@ -109,6 +111,10 @@
 %%       root rights</li>
 %%   <li>`{cd,_}' -- when set, the subprocess will be spawned in specified
 %%       directory</li>
+%%   <li>`{environ,_}' -- set environment variables for the subprocess.
+%%       Overrides `environ_pass'</li>
+%%   <li>`{environ_pass,_}' -- list of environment variables in the current
+%%       environment to pass through to the subprocess</li>
 %%   <li>`{argv0,_}' -- when set, process name (sometimes called `argv[0]' or
 %%       `$0') will be set to this value</li>
 %% </ul>


### PR DESCRIPTION
The {environ, EnvMap} option sets values in the environment of the
executed process, using the key of the map as the environment variable
name and the value of the map as the environment variable's value.

The {environ_pass, EnvList} option takes a list of environment variable
names, and takes their values from the current environment to pass into
the subprocess.

If a variable is specified in both options, the environ option takes
precedence.
